### PR TITLE
55-fix: path for prettier in .lintstagedrc file

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
   "./src/**/*.{js,ts}": "eslint --fix",
   "./src/**/*.css": "stylelint --fix",
-  "/*.{json,html,js,ts,css}": "prettier --write"
+  "./src/**/*.{json,html,js,ts,css}": "prettier --write"
 }


### PR DESCRIPTION
## Description
Path corrected to "./src/**/*.{json,html,js,ts,css}". Prettier is works.


## Checklist
- [x] Follow project’s code style
- [ ] Add tests where applicable
- [x] No console errors/warnings
