### PR TITLE
13-feat: show/hide password checkbox implementation

### DIFF
--- a/src/components/login/form.ts
+++ b/src/components/login/form.ts
@@ -1,22 +1,14 @@
 import { LOGIN } from '../../pages/login/constants';
 import { loginButton } from '../../shared/components/button';
+import { createCredentials } from '../../shared/components/credentials';
 import { CHECKBOX } from '../../shared/styles';
-import { emailInput, passwordInput } from '../../shared/ui-config/credential-inputs';
-import {
-  createDiv,
-  createFieldset,
-  createForm,
-  createInput,
-  createLabel,
-} from '../../utils/create-elements/create-tags';
+import { createDiv, createForm, createInput, createLabel } from '../../utils/create-elements/create-tags';
+import { togglePasswordEmitter } from '../../utils/event-emitter';
 
 export function form(): HTMLFormElement {
   const togglePasswordContainer = createDiv({ classes: [...CHECKBOX.general, ...CHECKBOX.login] });
 
-  const credentialsFieldset = createFieldset({
-    children: [emailInput.container, passwordInput.container, togglePasswordContainer],
-    classes: LOGIN.inputsContainer,
-  });
+  const credentialsFieldset = createCredentials();
 
   createInput({
     attributes: {
@@ -26,7 +18,7 @@ export function form(): HTMLFormElement {
     events: {
       change: (event: Event) => {
         if (event.target instanceof HTMLInputElement) {
-          console.log(`Show password: ${event.target.checked}`);
+          togglePasswordEmitter.emit('togglePassword', event.target.checked);
         }
       },
     },
@@ -35,7 +27,7 @@ export function form(): HTMLFormElement {
   createLabel({ attributes: { for: 'password' }, parent: togglePasswordContainer, text: 'Show password' });
 
   return createForm({
-    children: [credentialsFieldset, loginButton],
+    children: [credentialsFieldset, togglePasswordContainer, loginButton],
     classes: LOGIN.form,
   });
 }

--- a/src/components/login/form.ts
+++ b/src/components/login/form.ts
@@ -1,9 +1,8 @@
 import { LOGIN } from '../../pages/login/constants';
 import { loginButton } from '../../shared/components/button';
-import { createCredentials } from '../../shared/components/credentials';
+import { createCredentials, togglePasswordEmitter } from '../../shared/components/credentials';
 import { CHECKBOX } from '../../shared/styles';
 import { createDiv, createForm, createInput, createLabel } from '../../utils/create-elements/create-tags';
-import { togglePasswordEmitter } from '../../utils/event-emitter';
 
 export function form(): HTMLFormElement {
   const togglePasswordContainer = createDiv({ classes: [...CHECKBOX.general, ...CHECKBOX.login] });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,1 @@
 import './style.css';
-import { LoginPage } from './pages/login';
-
-LoginPage();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,1 +1,4 @@
 import './style.css';
+import { LoginPage } from './pages/login';
+
+LoginPage();

--- a/src/shared/components/credentials.ts
+++ b/src/shared/components/credentials.ts
@@ -1,8 +1,10 @@
 import { REGISTRATION } from '../../pages/registration/constants';
 import { createFieldset } from '../../utils/create-elements/create-tags';
-import { togglePasswordEmitter } from '../../utils/event-emitter';
+import { CustomEventEmitter } from '../../utils/event-emitter';
 import { CREDENTIALS_INPUT_CONFIG } from '../ui-config/credential-inputs';
 import { createWrappedInput } from './input';
+
+export const togglePasswordEmitter = new CustomEventEmitter();
 
 export function createCredentials(): HTMLFieldSetElement {
   const emailInput = createWrappedInput(CREDENTIALS_INPUT_CONFIG.email);

--- a/src/shared/components/credentials.ts
+++ b/src/shared/components/credentials.ts
@@ -1,11 +1,18 @@
 import { REGISTRATION } from '../../pages/registration/constants';
 import { createFieldset } from '../../utils/create-elements/create-tags';
+import { togglePasswordEmitter } from '../../utils/event-emitter';
 import { CREDENTIALS_INPUT_CONFIG } from '../ui-config/credential-inputs';
 import { createWrappedInput } from './input';
 
 export function createCredentials(): HTMLFieldSetElement {
   const emailInput = createWrappedInput(CREDENTIALS_INPUT_CONFIG.email);
   const passwordInput = createWrappedInput(CREDENTIALS_INPUT_CONFIG.password);
+
+  togglePasswordEmitter.subscribe('togglePassword', (isVisible) => {
+    if (passwordInput.input instanceof HTMLInputElement) {
+      passwordInput.input.type = isVisible ? 'text' : 'password';
+    }
+  });
 
   const credentialsFieldset = createFieldset({
     children: [emailInput.container, passwordInput.container],

--- a/src/utils/event-emitter.ts
+++ b/src/utils/event-emitter.ts
@@ -1,0 +1,21 @@
+class CustomEventEmitter {
+  private events: Record<string, ((...arguments_: unknown[]) => void)[]> = {};
+
+  public emit(event: string, ...arguments_: unknown[]): void {
+    if (this.events[event]) {
+      for (const listener of this.events[event]) {
+        listener(...arguments_);
+      }
+    }
+  }
+
+  public subscribe(event: string, listener: (...arguments_: unknown[]) => void): void {
+    if (!this.events[event]) {
+      this.events[event] = [];
+    }
+
+    this.events[event].push(listener);
+  }
+}
+
+export const togglePasswordEmitter = new CustomEventEmitter();

--- a/src/utils/event-emitter.ts
+++ b/src/utils/event-emitter.ts
@@ -1,4 +1,4 @@
-class CustomEventEmitter {
+export class CustomEventEmitter {
   private events: Record<string, ((...arguments_: unknown[]) => void)[]> = {};
 
   public emit(event: string, ...arguments_: unknown[]): void {
@@ -17,5 +17,3 @@ class CustomEventEmitter {
     this.events[event].push(listener);
   }
 }
-
-export const togglePasswordEmitter = new CustomEventEmitter();


### PR DESCRIPTION
## Description

Implement show/hide functionality for password field. Other than that, event emitter was implemented.

- [x] When checkbox is activated, users is able to see their password in plaintext.
- [x] When checkbox is deactivated, the password is replaced with asterisks or bullet points.

## Checklist

- [x] Follow project’s code style
- [ ] Add tests where applicable
- [x] No console errors/warnings

## Notes

To test this code add following lines in main.ts:
```ts
import { LoginPage } from './pages/login';

LoginPage();
```