### PR TITLE
115-fix: fix bug that sends empty date of birth to the server

### DIFF
--- a/src/helpers/reset-state-logout.ts
+++ b/src/helpers/reset-state-logout.ts
@@ -7,7 +7,7 @@ export function resetState(): void {
   const stateKeys = Object.keys(registrationState).filter((key) => !excludedKeys.has(key));
 
   for (const key of stateKeys) {
-    registrationState[key] = { error: false, rawValue: '', value: '' };
+    registrationState[key] = { error: undefined, rawValue: '', value: '' };
   }
 
   for (const key of excludedKeys) {


### PR DESCRIPTION
## Description

Fixed a bug.
The app sent a request to the server when the "Date of Birth" field was empty during the second registration.
This caused wrong data to be sent
