### PR TITLE
127-feat: implement changing user's password

### DIFF
--- a/src/app/api/update-personal-data.ts
+++ b/src/app/api/update-personal-data.ts
@@ -1,13 +1,6 @@
 import type { Customer } from '@commercetools/platform-sdk';
 import { API_URL, PROJECT_KEY } from '../constants';
-import type { FetchError } from '../types';
-
-type PersonalData = {
-  firstName: string;
-  lastName: string;
-  dateOfBirth: string;
-  email: string;
-};
+import type { FetchError, PersonalData } from '../types';
 
 export async function updatePersonalData(
   updatedData: PersonalData,

--- a/src/app/api/update-user-password.ts
+++ b/src/app/api/update-user-password.ts
@@ -1,0 +1,35 @@
+import type { Customer } from '@commercetools/platform-sdk';
+import type { FetchError, UpdatedPassword } from '../types';
+import { API_URL, PROJECT_KEY } from '../constants';
+
+export async function updateUserPassword(
+  updatedPassword: UpdatedPassword,
+  version: number,
+  accessToken: string,
+  customerId: string,
+): Promise<Customer | FetchError> {
+  try {
+    const response = await fetch(`${API_URL}/${PROJECT_KEY}/me/password`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ ...updatedPassword, version, customerId }),
+    });
+
+    console.log(response);
+
+    if (!response.ok) {
+      const error = await response.json();
+
+      return { message: error.message || 'Failed to update new password' };
+    }
+
+    const updatedCustomer = await response.json();
+
+    return updatedCustomer;
+  } catch {
+    return { message: 'Unexpected error during updating new password' };
+  }
+}

--- a/src/app/state/profile/password-state.ts
+++ b/src/app/state/profile/password-state.ts
@@ -1,0 +1,14 @@
+import type { ProfileDataState } from '../../types';
+
+export const passwordState: ProfileDataState = {
+  currentPassword: {
+    error: undefined,
+    rawValue: '',
+    value: '',
+  },
+  newPassword: {
+    error: undefined,
+    rawValue: '',
+    value: '',
+  },
+};

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -63,3 +63,15 @@ export type ProfileDataState = Record<string, FieldState>;
 export type FetchError = {
   message: string;
 };
+
+export type UpdatedPassword = {
+  currentPassword: string;
+  newPassword: string;
+};
+
+export type PersonalData = {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  email: string;
+};

--- a/src/components/profile/layout.ts
+++ b/src/components/profile/layout.ts
@@ -1,17 +1,23 @@
 import { PROFILE_CLASSES } from '../../pages/profile/constants';
 import { HEADER2 } from '../../shared/styles';
 import { createDiv, createH2 } from '../../utils/create-elements/create-tags';
+import { createPasswordSection } from './password-section/password-section';
 import { createPersonalInfoSection } from './personal-info-section/personal-info';
 
 export async function profileLayout(): Promise<HTMLDivElement | void> {
   const title = createH2({ classes: HEADER2.general, text: 'Personal Profile' });
-  const personalInfoSection = await createPersonalInfoSection();
 
-  if (!(personalInfoSection instanceof HTMLDivElement)) {
+  const personalInfoSection = await createPersonalInfoSection();
+  const passwordSection = await createPasswordSection();
+
+  if (!(personalInfoSection instanceof HTMLDivElement && passwordSection instanceof HTMLDivElement)) {
     return;
   }
 
-  const layout = createDiv({ classes: PROFILE_CLASSES.wrapper, children: [title, personalInfoSection] });
+  const layout = createDiv({
+    classes: PROFILE_CLASSES.wrapper,
+    children: [title, personalInfoSection, passwordSection],
+  });
 
   return layout;
 }

--- a/src/components/profile/password-section/password-section.ts
+++ b/src/components/profile/password-section/password-section.ts
@@ -1,0 +1,42 @@
+import { getUserInfo } from '../../../app/api';
+import { getAuthToken } from '../../../app/ecommerce/get-auth-token';
+import type { FetchError } from '../../../app/types';
+import { activateButtonEmitter, passwordEmitter } from '../../../helpers/buttons-emitter';
+import { PASSWORD_BUTTONS_CONFIG, PROFILE_CLASSES, PROFILE_CONFIG } from '../../../pages/profile/constants';
+import { createWrappedInput } from '../../../shared/components/input';
+import { createButton, createDiv } from '../../../utils/create-elements/create-tags';
+
+export async function createPasswordSection(): Promise<FetchError | HTMLDivElement> {
+  //! Delete in the future when I save token in local/session storage
+  const token = await getAuthToken('ivanIvanov@yandex.ru', 'Ivan12345');
+
+  if (typeof token !== 'string') {
+    return { message: 'Failed to get token' };
+  }
+
+  const user = await getUserInfo(token);
+
+  if (!('id' in user)) {
+    return { message: 'Failed to get Personal Data' };
+  }
+
+  const currentPasswordWrapper = createWrappedInput(PROFILE_CONFIG.currentPassword);
+  const newPasswordWrapper = createWrappedInput(PROFILE_CONFIG.newPassword);
+
+  const editButton = createButton(PASSWORD_BUTTONS_CONFIG.edit);
+  const saveButton = createButton(PASSWORD_BUTTONS_CONFIG.save);
+  const cancelButton = createButton(PASSWORD_BUTTONS_CONFIG.cancel);
+
+  const inputWrappers = [currentPasswordWrapper, newPasswordWrapper];
+  const inputContainers = inputWrappers.map((inputWrapper) => inputWrapper.container);
+  const buttons = [editButton, saveButton, cancelButton];
+
+  activateButtonEmitter(passwordEmitter, buttons, inputWrappers);
+
+  const personalInfoSection = createDiv({
+    classes: PROFILE_CLASSES.section,
+    children: [...inputContainers, editButton, saveButton, cancelButton],
+  });
+
+  return personalInfoSection;
+}

--- a/src/components/profile/password-section/password-section.ts
+++ b/src/components/profile/password-section/password-section.ts
@@ -2,6 +2,7 @@ import { getUserInfo } from '../../../app/api';
 import { getAuthToken } from '../../../app/ecommerce/get-auth-token';
 import type { FetchError } from '../../../app/types';
 import { activateButtonEmitter, passwordEmitter } from '../../../helpers/buttons-emitter';
+import { updatePasswordEmitter } from '../../../helpers/update-personal-data-emitter';
 import { PASSWORD_BUTTONS_CONFIG, PROFILE_CLASSES, PROFILE_CONFIG } from '../../../pages/profile/constants';
 import { createWrappedInput } from '../../../shared/components/input';
 import { createButton, createDiv } from '../../../utils/create-elements/create-tags';
@@ -27,15 +28,18 @@ export async function createPasswordSection(): Promise<FetchError | HTMLDivEleme
   const saveButton = createButton(PASSWORD_BUTTONS_CONFIG.save);
   const cancelButton = createButton(PASSWORD_BUTTONS_CONFIG.cancel);
 
-  const inputWrappers = [currentPasswordWrapper, newPasswordWrapper];
-  const inputContainers = inputWrappers.map((inputWrapper) => inputWrapper.container);
   const buttons = [editButton, saveButton, cancelButton];
 
+  const inputWrappers = [currentPasswordWrapper, newPasswordWrapper];
+  const inputContainers = inputWrappers.map((inputWrapper) => inputWrapper.container);
+  const inputs = inputWrappers.map((inputWrapper) => inputWrapper.input);
+
   activateButtonEmitter(passwordEmitter, buttons, inputWrappers);
+  updatePasswordEmitter(inputs);
 
   const personalInfoSection = createDiv({
     classes: PROFILE_CLASSES.section,
-    children: [...inputContainers, editButton, saveButton, cancelButton],
+    children: [...inputContainers, ...buttons],
   });
 
   return personalInfoSection;

--- a/src/components/profile/personal-info-section/personal-info.ts
+++ b/src/components/profile/personal-info-section/personal-info.ts
@@ -49,7 +49,7 @@ export async function createPersonalInfoSection(): Promise<FetchError | HTMLDivE
 
   const personalInfoSection = createDiv({
     classes: PROFILE_CLASSES.section,
-    children: [...inputContainers, editButton, saveButton, cancelButton],
+    children: [...inputContainers, ...buttons],
   });
 
   return personalInfoSection;

--- a/src/components/profile/personal-info-section/personal-info.ts
+++ b/src/components/profile/personal-info-section/personal-info.ts
@@ -1,7 +1,7 @@
 import { getUserInfo } from '../../../app/api';
 import { getAuthToken } from '../../../app/ecommerce/get-auth-token';
 import type { FetchError } from '../../../app/types';
-import { activateButtonEmitter } from '../../../helpers/buttons-emitter';
+import { activateButtonEmitter, personalInfoEmitter } from '../../../helpers/buttons-emitter';
 import { createWrappedInput } from '../../../shared/components/input';
 import { createButton, createDiv } from '../../../utils/create-elements/create-tags';
 import { BUTTONS_CONFIG, PROFILE_CLASSES, PROFILE_CONFIG } from '../../../pages/profile/constants';
@@ -34,15 +34,17 @@ export async function createPersonalInfoSection(): Promise<FetchError | HTMLDivE
   birthDateWrapper.input.value = user.dateOfBirth || 'undefined';
   emailWrapper.input.value = user.email || 'undefined';
 
-  const inputWrappers = [firstNameWrapper, lastNameWrapper, birthDateWrapper, emailWrapper];
-  const inputContainers = inputWrappers.map((inputWrapper) => inputWrapper.container);
-  const inputs = inputWrappers.map((inputWrapper) => inputWrapper.input);
-
   const editButton = createButton(BUTTONS_CONFIG.edit);
   const saveButton = createButton(BUTTONS_CONFIG.save);
   const cancelButton = createButton(BUTTONS_CONFIG.cancel);
 
-  activateButtonEmitter(editButton, saveButton, cancelButton, inputWrappers);
+  const buttons = [editButton, saveButton, cancelButton];
+
+  const inputWrappers = [firstNameWrapper, lastNameWrapper, birthDateWrapper, emailWrapper];
+  const inputContainers = inputWrappers.map((inputWrapper) => inputWrapper.container);
+  const inputs = inputWrappers.map((inputWrapper) => inputWrapper.input);
+
+  activateButtonEmitter(personalInfoEmitter, buttons, inputWrappers);
   updatePersonalDataEmitter(inputs);
 
   const personalInfoSection = createDiv({

--- a/src/helpers/button-config-creator.ts
+++ b/src/helpers/button-config-creator.ts
@@ -1,0 +1,44 @@
+import { PROFILE_CLASSES } from '../pages/profile/constants';
+
+type ButtonConfig = {
+  classes: string[];
+  text: string;
+  events: {
+    click: () => void | Promise<void>;
+  };
+  attributes?: Record<'disabled', 'true'>;
+};
+
+type ButtonParameters = {
+  onEdit: () => void;
+  onSave: () => Promise<void>;
+  onCancel: () => void;
+};
+
+type ButtonsConfig = {
+  edit: ButtonConfig;
+  save: ButtonConfig;
+  cancel: ButtonConfig;
+};
+
+export function createButtonsConfig({ onEdit, onSave, onCancel }: ButtonParameters): ButtonsConfig {
+  return {
+    edit: {
+      classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonEdit],
+      events: { click: onEdit },
+      text: 'Edit',
+    },
+    save: {
+      attributes: { disabled: 'true' },
+      classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonSave],
+      events: { click: onSave },
+      text: 'Save',
+    },
+    cancel: {
+      attributes: { disabled: 'true' },
+      classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonCancel],
+      events: { click: onCancel },
+      text: 'Cancel',
+    },
+  };
+}

--- a/src/helpers/buttons-emitter.ts
+++ b/src/helpers/buttons-emitter.ts
@@ -23,6 +23,12 @@ function clearErrors(wrappers: WrappedInput[]): void {
   }
 }
 
+function clearInputValues(inputs: HTMLInputElement[]): void {
+  for (const input of inputs) {
+    input.value = '';
+  }
+}
+
 export function activateButtonEmitter(
   emitter: CustomEventEmitter,
   buttons: HTMLButtonElement[],
@@ -38,6 +44,10 @@ export function activateButtonEmitter(
   emitter.subscribe('saveBtnClick', () => {
     toggleButtons(buttons, false);
     toggleInputs(inputs, false);
+
+    if (emitter === passwordEmitter) {
+      clearInputValues(inputs);
+    }
   });
 
   emitter.subscribe('cancelBtnClick', async () => {
@@ -46,6 +56,10 @@ export function activateButtonEmitter(
 
     if (emitter === personalInfoEmitter) {
       await resetInputDisplayFromServer(inputs);
+    }
+
+    if (emitter === passwordEmitter) {
+      clearInputValues(inputs);
     }
 
     clearErrors(wrappers);

--- a/src/helpers/buttons-emitter.ts
+++ b/src/helpers/buttons-emitter.ts
@@ -2,14 +2,10 @@ import { CustomEventEmitter } from '../utils/event-emitter';
 import type { WrappedInput } from '../shared/components/input';
 import { resetInputDisplayFromServer } from './reset-input-display-from-server';
 
-export const buttonEmitter = new CustomEventEmitter();
+export const personalInfoEmitter = new CustomEventEmitter();
+export const passwordEmitter = new CustomEventEmitter();
 
-function toggleButtons(
-  edit: HTMLButtonElement,
-  save: HTMLButtonElement,
-  cancel: HTMLButtonElement,
-  isEditMode: boolean,
-): void {
+function toggleButtons([edit, save, cancel]: HTMLButtonElement[], isEditMode: boolean): void {
   edit.disabled = isEditMode;
   save.disabled = !isEditMode;
   cancel.disabled = !isEditMode;
@@ -28,28 +24,30 @@ function clearErrors(wrappers: WrappedInput[]): void {
 }
 
 export function activateButtonEmitter(
-  editButton: HTMLButtonElement,
-  saveButton: HTMLButtonElement,
-  cancelButton: HTMLButtonElement,
+  emitter: CustomEventEmitter,
+  buttons: HTMLButtonElement[],
   wrappers: WrappedInput[],
 ): void {
   const inputs = wrappers.map((wrapper) => wrapper.input);
 
-  buttonEmitter.subscribe('editBtnClick', () => {
-    toggleButtons(editButton, saveButton, cancelButton, true);
+  emitter.subscribe('editBtnClick', () => {
+    toggleButtons(buttons, true);
     toggleInputs(inputs, true);
   });
 
-  buttonEmitter.subscribe('saveBtnClick', () => {
-    toggleButtons(editButton, saveButton, cancelButton, false);
+  emitter.subscribe('saveBtnClick', () => {
+    toggleButtons(buttons, false);
     toggleInputs(inputs, false);
   });
 
-  buttonEmitter.subscribe('cancelBtnClick', async () => {
-    toggleButtons(editButton, saveButton, cancelButton, false);
+  emitter.subscribe('cancelBtnClick', async () => {
+    toggleButtons(buttons, false);
     toggleInputs(inputs, false);
-    clearErrors(wrappers);
 
-    await resetInputDisplayFromServer(inputs);
+    if (emitter === personalInfoEmitter) {
+      await resetInputDisplayFromServer(inputs);
+    }
+
+    clearErrors(wrappers);
   });
 }

--- a/src/helpers/update-personal-data-emitter.ts
+++ b/src/helpers/update-personal-data-emitter.ts
@@ -1,9 +1,11 @@
 import { getUserInfo, updatePersonalData } from '../app/api';
+import { updateUserPassword } from '../app/api/update-user-password';
 import { getAuthToken } from '../app/ecommerce/get-auth-token';
 import type { FetchError } from '../app/types';
 import { CustomEventEmitterAsync } from '../utils/event-emitter';
 
 export const personalDataEmitterAsync = new CustomEventEmitterAsync();
+export const passwordEmitterAsync = new CustomEventEmitterAsync();
 
 export async function updatePersonalDataEmitter(inputs: HTMLInputElement[]): Promise<FetchError | void> {
   personalDataEmitterAsync.subscribe('updateUserData', async () => {
@@ -35,8 +37,44 @@ export async function updatePersonalDataEmitter(inputs: HTMLInputElement[]): Pro
       if (!('id' in updatedUser)) {
         throw new Error(updatedUser.message);
       }
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new TypeError(error.message);
+      }
 
-      console.log('Updated user', updatedUser);
+      throw new Error('Unexpected error');
+    }
+  });
+}
+
+export async function updatePasswordEmitter(inputs: HTMLInputElement[]): Promise<FetchError | void> {
+  passwordEmitterAsync.subscribe('updatePassword', async () => {
+    const [currentPassword, newPassword] = inputs;
+
+    try {
+      //! Delete in the future when I save token via local/session storage
+      const token = await getAuthToken('ivanIvanov@yandex.ru', 'Ivan12345');
+
+      if (typeof token !== 'string') {
+        return { message: 'Failed to get token to update Personal Data' };
+      }
+
+      const user = await getUserInfo(token);
+
+      if (!('id' in user)) {
+        return { message: 'Failed to get User Data' };
+      }
+
+      const updatedPassword = {
+        currentPassword: currentPassword.value,
+        newPassword: newPassword.value,
+      };
+
+      const updatedUser = await updateUserPassword(updatedPassword, user.version, token, user.id);
+
+      if (!('id' in updatedUser)) {
+        throw new Error(updatedUser.message);
+      }
     } catch (error) {
       if (error instanceof Error) {
         throw new TypeError(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,12 @@
-import { ProfilePage } from './pages/profile';
 import './style.css';
-// import { appState } from './app/app-state';
-// import { renderPage } from './app/router/render-page';
-// import { router } from './app/router/router';
-// import { checkRenderPage } from './app/router/handlers';
+import { appState } from './app/app-state';
+import { renderPage } from './app/router/render-page';
+import { router } from './app/router/router';
+import { checkRenderPage } from './app/router/handlers';
 
-// (function (): void {
-//   router();
-//   appState.currentPage = checkRenderPage(globalThis.location.hash.slice(1).trim());
-//   renderPage(appState.currentPage);
-//   globalThis.location.hash = `#${appState.currentPage}`;
-// })();
-
-ProfilePage();
+(function (): void {
+  router();
+  appState.currentPage = checkRenderPage(globalThis.location.hash.slice(1).trim());
+  renderPage(appState.currentPage);
+  globalThis.location.hash = `#${appState.currentPage}`;
+})();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,15 @@
+import { ProfilePage } from './pages/profile';
 import './style.css';
-import { appState } from './app/app-state';
-import { renderPage } from './app/router/render-page';
-import { router } from './app/router/router';
-import { checkRenderPage } from './app/router/handlers';
+// import { appState } from './app/app-state';
+// import { renderPage } from './app/router/render-page';
+// import { router } from './app/router/router';
+// import { checkRenderPage } from './app/router/handlers';
 
-(function (): void {
-  router();
-  appState.currentPage = checkRenderPage(globalThis.location.hash.slice(1).trim());
-  renderPage(appState.currentPage);
-  globalThis.location.hash = `#${appState.currentPage}`;
-})();
+// (function (): void {
+//   router();
+//   appState.currentPage = checkRenderPage(globalThis.location.hash.slice(1).trim());
+//   renderPage(appState.currentPage);
+//   globalThis.location.hash = `#${appState.currentPage}`;
+// })();
+
+ProfilePage();

--- a/src/pages/profile/constants.ts
+++ b/src/pages/profile/constants.ts
@@ -10,6 +10,7 @@ import { profileDataState } from '../../app/state/profile/profile-state';
 import { passwordEmitterAsync, personalDataEmitterAsync } from '../../helpers/update-personal-data-emitter';
 import { passwordState } from '../../app/state/profile/password-state';
 import { personalInfoEmitter, passwordEmitter } from '../../helpers/buttons-emitter';
+import { createButtonsConfig } from '../../helpers/button-config-creator';
 
 export const MESSAGES = {
   INVALID_DATA: 'Please enter valid profile information',
@@ -173,110 +174,59 @@ export const PROFILE_CONFIG = {
   },
 };
 
-export const BUTTONS_CONFIG = {
-  edit: {
-    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonEdit],
-    events: {
-      click: async () => {
-        personalInfoEmitter.emit('editBtnClick');
-      },
-    },
-    text: 'Edit',
+export const BUTTONS_CONFIG = createButtonsConfig({
+  onEdit: () => personalInfoEmitter.emit('editBtnClick'),
+
+  onSave: async () => {
+    try {
+      const isFormValid = validateDataForm(profileDataState);
+
+      if (!isFormValid) {
+        createPopupMessage(MESSAGES.INVALID_DATA, false);
+        return;
+      }
+
+      await personalDataEmitterAsync.emit('updateUserData');
+      personalInfoEmitter.emit('saveBtnClick');
+
+      createPopupMessage(MESSAGES.INFORMATION_SAVED, true);
+    } catch (error) {
+      if (error instanceof Error) {
+        createPopupMessage(error.message, false);
+        return;
+      }
+
+      createPopupMessage(SERVER_ERROR_MESSAGES.EMAIL, false);
+    }
   },
-  save: {
-    attributes: {
-      disabled: 'true',
-    },
-    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonSave],
-    events: {
-      click: async () => {
-        try {
-          const isFormValid = validateDataForm(profileDataState);
 
-          if (!isFormValid) {
-            createPopupMessage(MESSAGES.INVALID_DATA, false);
-            return;
-          }
+  onCancel: () => personalInfoEmitter.emit('cancelBtnClick'),
+});
 
-          await personalDataEmitterAsync.emit('updateUserData');
-          personalInfoEmitter.emit('saveBtnClick');
+export const PASSWORD_BUTTONS_CONFIG = createButtonsConfig({
+  onEdit: () => passwordEmitter.emit('editBtnClick'),
 
-          createPopupMessage(MESSAGES.INFORMATION_SAVED, true);
-        } catch (error) {
-          if (error instanceof Error) {
-            createPopupMessage(error.message, false);
-            return;
-          }
+  onSave: async () => {
+    try {
+      const isFormValid = validateDataForm(passwordState);
 
-          createPopupMessage(SERVER_ERROR_MESSAGES.EMAIL, false);
-        }
-      },
-    },
-    text: 'Save',
+      if (!isFormValid) {
+        createPopupMessage(MESSAGES.INVALID_PASSWORD, false);
+        return;
+      }
+
+      await passwordEmitterAsync.emit('updatePassword');
+      passwordEmitter.emit('saveBtnClick');
+
+      createPopupMessage(MESSAGES.PASSWORD_SAVED, true);
+    } catch (error) {
+      if (error instanceof Error) {
+        createPopupMessage(error.message, false);
+        return;
+      }
+      createPopupMessage(SERVER_ERROR_MESSAGES.PASSWORD, false);
+    }
   },
-  cancel: {
-    attributes: {
-      disabled: 'true',
-    },
-    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonCancel],
-    events: {
-      click: () => {
-        personalInfoEmitter.emit('cancelBtnClick');
-      },
-    },
-    text: 'Cancel',
-  },
-};
 
-export const PASSWORD_BUTTONS_CONFIG = {
-  edit: {
-    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonEdit],
-    events: {
-      click: async () => {
-        passwordEmitter.emit('editBtnClick');
-      },
-    },
-    text: 'Edit',
-  },
-  save: {
-    attributes: {
-      disabled: 'true',
-    },
-    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonSave],
-    events: {
-      click: async () => {
-        try {
-          const isFormValid = validateDataForm(passwordState);
-
-          if (!isFormValid) {
-            createPopupMessage(MESSAGES.INVALID_PASSWORD, false);
-            return;
-          }
-
-          await passwordEmitterAsync.emit('updatePassword');
-          passwordEmitter.emit('saveBtnClick');
-          createPopupMessage(MESSAGES.PASSWORD_SAVED, true);
-        } catch (error) {
-          if (error instanceof Error) {
-            createPopupMessage(error.message, false);
-            return;
-          }
-          createPopupMessage(SERVER_ERROR_MESSAGES.PASSWORD, false);
-        }
-      },
-    },
-    text: 'Save',
-  },
-  cancel: {
-    attributes: {
-      disabled: 'true',
-    },
-    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonCancel],
-    events: {
-      click: () => {
-        passwordEmitter.emit('cancelBtnClick');
-      },
-    },
-    text: 'Cancel',
-  },
-};
+  onCancel: () => passwordEmitter.emit('cancelBtnClick'),
+});

--- a/src/pages/profile/constants.ts
+++ b/src/pages/profile/constants.ts
@@ -11,6 +11,18 @@ import { passwordEmitterAsync, personalDataEmitterAsync } from '../../helpers/up
 import { passwordState } from '../../app/state/profile/password-state';
 import { personalInfoEmitter, passwordEmitter } from '../../helpers/buttons-emitter';
 
+export const MESSAGES = {
+  INVALID_DATA: 'Please enter valid profile information',
+  INVALID_PASSWORD: 'Please enter valid password',
+  INFORMATION_SAVED: 'Your information has been successfully saved',
+  PASSWORD_SAVED: 'Your password has been successfully saved',
+};
+
+export const SERVER_ERROR_MESSAGES = {
+  EMAIL: 'Unexpected error during updating email',
+  PASSWORD: 'Unexpected error during saving password',
+};
+
 export const PROFILE_CLASSES = {
   baseButton: [
     'w-20',
@@ -182,21 +194,21 @@ export const BUTTONS_CONFIG = {
           const isFormValid = validateDataForm(profileDataState);
 
           if (!isFormValid) {
-            createPopupMessage('Please enter valid profile information', false);
+            createPopupMessage(MESSAGES.INVALID_DATA, false);
             return;
           }
 
           await personalDataEmitterAsync.emit('updateUserData');
           personalInfoEmitter.emit('saveBtnClick');
 
-          createPopupMessage('Your information has been successfully saved', true);
+          createPopupMessage(MESSAGES.INFORMATION_SAVED, true);
         } catch (error) {
           if (error instanceof Error) {
             createPopupMessage(error.message, false);
             return;
           }
 
-          createPopupMessage('Unexpected error during updating email', false);
+          createPopupMessage(SERVER_ERROR_MESSAGES.EMAIL, false);
         }
       },
     },
@@ -237,19 +249,19 @@ export const PASSWORD_BUTTONS_CONFIG = {
           const isFormValid = validateDataForm(passwordState);
 
           if (!isFormValid) {
-            createPopupMessage('Please enter valid password', false);
+            createPopupMessage(MESSAGES.INVALID_PASSWORD, false);
             return;
           }
 
           await passwordEmitterAsync.emit('updatePassword');
           passwordEmitter.emit('saveBtnClick');
-          createPopupMessage('Your password has been successfully saved', true);
+          createPopupMessage(MESSAGES.PASSWORD_SAVED, true);
         } catch (error) {
           if (error instanceof Error) {
             createPopupMessage(error.message, false);
             return;
           }
-          createPopupMessage('Unexpected error during saving password', false);
+          createPopupMessage(SERVER_ERROR_MESSAGES.PASSWORD, false);
         }
       },
     },

--- a/src/pages/profile/constants.ts
+++ b/src/pages/profile/constants.ts
@@ -1,10 +1,15 @@
-import { dateOfBirthValidation, inputValidation } from '../../utils/validation/profile/input-validation';
+import {
+  dateOfBirthValidation,
+  inputPasswordValidation,
+  inputValidation,
+} from '../../utils/validation/profile/input-validation';
 import { ERROR_MESSAGES, REGEX } from '../../shared/constants';
-import { buttonEmitter } from '../../helpers/buttons-emitter';
 import { validatePersonalDataForm } from '../../utils/validation/profile/personal-data-form-validation';
 import { createPopupMessage } from '../../shared/components/popup';
 import { profileDataState } from '../../app/state/profile/profile-state';
 import { personalDataEmitterAsync } from '../../helpers/update-personal-data-emitter';
+import { passwordState } from '../../app/state/profile/password-state';
+import { personalInfoEmitter, passwordEmitter } from '../../helpers/buttons-emitter';
 
 export const PROFILE_CLASSES = {
   baseButton: [
@@ -106,6 +111,54 @@ export const PROFILE_CONFIG = {
       },
     },
   },
+  currentPassword: {
+    attributes: {
+      disabled: 'true',
+      autocomplete: 'true',
+      name: 'currentPassword',
+      placeholder: 'Enter your current password*',
+      type: 'password',
+    },
+    classes: PROFILE_CLASSES.input,
+    events: {
+      input: (event: Event) => {
+        inputPasswordValidation(event, REGEX.PASSWORD_LOWERCASE, ERROR_MESSAGES.PASSWORD_LOWERCASE);
+        if (!passwordState.currentPassword.error) {
+          inputPasswordValidation(event, REGEX.PASSWORD_UPPERCASE, ERROR_MESSAGES.PASSWORD_UPPERCASE);
+        }
+        if (!passwordState.currentPassword.error) {
+          inputPasswordValidation(event, REGEX.PASSWORD_NUMBER, ERROR_MESSAGES.PASSWORD_NUMBER);
+        }
+        if (!passwordState.currentPassword.error) {
+          inputPasswordValidation(event, REGEX.PASSWORD_LENGTH, ERROR_MESSAGES.PASSWORD_LENGTH);
+        }
+      },
+    },
+  },
+  newPassword: {
+    attributes: {
+      disabled: 'true',
+      autocomplete: 'true',
+      name: 'newPassword',
+      placeholder: 'Enter your new password*',
+      type: 'password',
+    },
+    classes: PROFILE_CLASSES.input,
+    events: {
+      input: (event: Event) => {
+        inputPasswordValidation(event, REGEX.PASSWORD_LOWERCASE, ERROR_MESSAGES.PASSWORD_LOWERCASE);
+        if (!passwordState.newPassword.error) {
+          inputPasswordValidation(event, REGEX.PASSWORD_UPPERCASE, ERROR_MESSAGES.PASSWORD_UPPERCASE);
+        }
+        if (!passwordState.newPassword.error) {
+          inputPasswordValidation(event, REGEX.PASSWORD_NUMBER, ERROR_MESSAGES.PASSWORD_NUMBER);
+        }
+        if (!passwordState.newPassword.error) {
+          inputPasswordValidation(event, REGEX.PASSWORD_LENGTH, ERROR_MESSAGES.PASSWORD_LENGTH);
+        }
+      },
+    },
+  },
 };
 
 export const BUTTONS_CONFIG = {
@@ -113,7 +166,7 @@ export const BUTTONS_CONFIG = {
     classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonEdit],
     events: {
       click: async () => {
-        buttonEmitter.emit('editBtnClick');
+        personalInfoEmitter.emit('editBtnClick');
       },
     },
     text: 'Edit',
@@ -134,7 +187,7 @@ export const BUTTONS_CONFIG = {
           }
 
           await personalDataEmitterAsync.emit('updateUserData');
-          buttonEmitter.emit('saveBtnClick');
+          personalInfoEmitter.emit('saveBtnClick');
 
           createPopupMessage('Your information has been successfully saved', true);
         } catch (error) {
@@ -156,7 +209,58 @@ export const BUTTONS_CONFIG = {
     classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonCancel],
     events: {
       click: () => {
-        buttonEmitter.emit('cancelBtnClick');
+        personalInfoEmitter.emit('cancelBtnClick');
+      },
+    },
+    text: 'Cancel',
+  },
+};
+
+export const PASSWORD_BUTTONS_CONFIG = {
+  edit: {
+    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonEdit],
+    events: {
+      click: async () => {
+        passwordEmitter.emit('editBtnClick');
+      },
+    },
+    text: 'Edit',
+  },
+  save: {
+    attributes: {
+      disabled: 'true',
+    },
+    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonSave],
+    events: {
+      click: async () => {
+        // try {
+        //   const isFormValid = validatePersonalDataForm();
+        //   if (!isFormValid) {
+        //     createPopupMessage('Please enter valid profile information', false);
+        //     return;
+        //   }
+        //   await personalDataEmitterAsync.emit('updateUserData');
+        //   passwordEmitter.emit('saveBtnClick');
+        //   createPopupMessage('Your information has been successfully saved', true);
+        // } catch (error) {
+        //   if (error instanceof Error) {
+        //     createPopupMessage(error.message, false);
+        //     return;
+        //   }
+        //   createPopupMessage('Unexpected error during updating email', false);
+        // }
+      },
+    },
+    text: 'Save',
+  },
+  cancel: {
+    attributes: {
+      disabled: 'true',
+    },
+    classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonCancel],
+    events: {
+      click: () => {
+        passwordEmitter.emit('cancelBtnClick');
       },
     },
     text: 'Cancel',

--- a/src/pages/profile/constants.ts
+++ b/src/pages/profile/constants.ts
@@ -237,7 +237,7 @@ export const PASSWORD_BUTTONS_CONFIG = {
           const isFormValid = validateDataForm(passwordState);
 
           if (!isFormValid) {
-            createPopupMessage('Please enter valid profile information', false);
+            createPopupMessage('Please enter valid password', false);
             return;
           }
 

--- a/src/pages/profile/constants.ts
+++ b/src/pages/profile/constants.ts
@@ -4,10 +4,10 @@ import {
   inputValidation,
 } from '../../utils/validation/profile/input-validation';
 import { ERROR_MESSAGES, REGEX } from '../../shared/constants';
-import { validatePersonalDataForm } from '../../utils/validation/profile/personal-data-form-validation';
+import { validateDataForm } from '../../utils/validation/profile/personal-data-form-validation';
 import { createPopupMessage } from '../../shared/components/popup';
 import { profileDataState } from '../../app/state/profile/profile-state';
-import { personalDataEmitterAsync } from '../../helpers/update-personal-data-emitter';
+import { passwordEmitterAsync, personalDataEmitterAsync } from '../../helpers/update-personal-data-emitter';
 import { passwordState } from '../../app/state/profile/password-state';
 import { personalInfoEmitter, passwordEmitter } from '../../helpers/buttons-emitter';
 
@@ -179,7 +179,7 @@ export const BUTTONS_CONFIG = {
     events: {
       click: async () => {
         try {
-          const isFormValid = validatePersonalDataForm();
+          const isFormValid = validateDataForm(profileDataState);
 
           if (!isFormValid) {
             createPopupMessage('Please enter valid profile information', false);
@@ -233,22 +233,24 @@ export const PASSWORD_BUTTONS_CONFIG = {
     classes: [...PROFILE_CLASSES.baseButton, ...PROFILE_CLASSES.buttonSave],
     events: {
       click: async () => {
-        // try {
-        //   const isFormValid = validatePersonalDataForm();
-        //   if (!isFormValid) {
-        //     createPopupMessage('Please enter valid profile information', false);
-        //     return;
-        //   }
-        //   await personalDataEmitterAsync.emit('updateUserData');
-        //   passwordEmitter.emit('saveBtnClick');
-        //   createPopupMessage('Your information has been successfully saved', true);
-        // } catch (error) {
-        //   if (error instanceof Error) {
-        //     createPopupMessage(error.message, false);
-        //     return;
-        //   }
-        //   createPopupMessage('Unexpected error during updating email', false);
-        // }
+        try {
+          const isFormValid = validateDataForm(passwordState);
+
+          if (!isFormValid) {
+            createPopupMessage('Please enter valid profile information', false);
+            return;
+          }
+
+          await passwordEmitterAsync.emit('updatePassword');
+          passwordEmitter.emit('saveBtnClick');
+          createPopupMessage('Your password has been successfully saved', true);
+        } catch (error) {
+          if (error instanceof Error) {
+            createPopupMessage(error.message, false);
+            return;
+          }
+          createPopupMessage('Unexpected error during saving password', false);
+        }
       },
     },
     text: 'Save',

--- a/src/utils/validation/profile/input-validation.ts
+++ b/src/utils/validation/profile/input-validation.ts
@@ -1,3 +1,4 @@
+import { passwordState } from '../../../app/state/profile/password-state';
 import { profileDataState } from '../../../app/state/profile/profile-state';
 import { createErrorMessage } from '../../../shared/components/error-message';
 import { MINIMUM_AGE } from '../../../shared/constants';
@@ -53,6 +54,31 @@ export function inputValidation(event: Event, regexp: RegExp, errorMessage: stri
         createErrorMessage(errorMessage, errorContainer);
         profileDataState[input.name].error = true;
         profileDataState[input.name].rawValue = input.value;
+      }
+    }
+  }
+}
+
+export function inputPasswordValidation(event: Event, regexp: RegExp, errorMessage: string): void {
+  const input = event.target;
+
+  if (input instanceof HTMLInputElement) {
+    const errorContainer = input.nextElementSibling;
+
+    if (errorContainer instanceof HTMLElement) {
+      errorContainer.replaceChildren();
+      const value = input.value;
+      input.value = value.replaceAll(/\s+/g, '');
+
+      if (regexp.test(input.value)) {
+        errorContainer.textContent = '';
+        passwordState[input.name].error = false;
+        passwordState[input.name].value = input.value.trim();
+        passwordState[input.name].rawValue = input.value;
+      } else {
+        createErrorMessage(errorMessage, errorContainer);
+        passwordState[input.name].error = true;
+        passwordState[input.name].rawValue = input.value;
       }
     }
   }

--- a/src/utils/validation/profile/personal-data-form-validation.ts
+++ b/src/utils/validation/profile/personal-data-form-validation.ts
@@ -1,8 +1,8 @@
-import { profileDataState } from '../../../app/state/profile/profile-state';
+import type { ProfileDataState } from '../../../app/types';
 
-export function validatePersonalDataForm(): boolean {
-  console.log(profileDataState);
-  const isFormValid = Object.values(profileDataState).every((value) => value.error === false);
+export function validateDataForm(state: ProfileDataState): boolean {
+  console.log('STATE:', state);
+  const isFormValid = Object.values(state).every((value) => value.error === false);
 
   return isFormValid;
 }


### PR DESCRIPTION
## Description

Users should have the capability to update their password within the application independently. This feature increases user autonomy and ensures they can maintain their account security up-to-date. [RSS-ECOMM-3_17](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_17.md)

## Definition of Done

- [x] Users can change their password separately from their other personal information on the User Profile page.
- [x] The system appropriately validates the new password based on the necessary criteria.
- [x] The user can save the changes, and is given a clear indication of the success or failure of this operation.

## Checklist

- [x] Follow project’s code style
- [ ] Add tests where applicable
- [x] No console errors/warnings

## Note

After updating the password, these files will also need changes because we don’t save the token yet. Now the token is hard-coded.

1. `src/components/profile/password-section/password-section.ts`

2. `src/components/profile/personal-info-section/personal-info.ts`

3. `src/helpers/reset-input-display-from-server.ts`

4. `src/helpers/update-personal-data-emitter.ts updatePersonalDataEmitter()`

5. `src/helpers/update-personal-data-emitter.ts updatePasswordEmitter()`


