### PR TITLE
175-chore: fix prettier warnings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "printWidth": 120,
   "plugins": ["prettier-plugin-tailwindcss"],
   "tailwindStylesheet": "./src/main.ts",
-  "tailwindConfig": "./tailwind.config.ts"
+  "tailwindConfig": "./tailwind.config.ts",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## Description

- [ ] Add "endOfLine": "auto" rule to prevent prettier from throwing incorrect carriage warnings.

## Checklist

- [x] Follow project’s code style
- [ ] Add tests where applicable
- [x] No console errors/warnings